### PR TITLE
consistent amd64/arm install format

### DIFF
--- a/prereqs.md
+++ b/prereqs.md
@@ -175,6 +175,11 @@ Install kind v0.16.0 by downloading it from the [kind release page](https://gith
 ```bash
 # amd64
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.16.0/kind-darwin-amd64 -o /tmp/kind
+-o /tmp/kind
+chmod +x /tmp/kind
+sudo mv /tmp/kind /usr/local/bin/kind
+sudo chown root: /usr/local/bin/kind
+
 # arm (if your Mac has an M1 CPU (”Apple Silicon”))
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.16.0/kind-darwin-arm64 -o /tmp/kind
 chmod +x /tmp/kind
@@ -190,6 +195,10 @@ Install clusterctl v1.2.3 by downloading it from the [ClusterAPI release page](h
 ```bash
 # amd64
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.3/clusterctl-darwin-amd64 -o /tmp/clusterctl
+chmod +x /tmp/clusterctl
+sudo mv /tmp/clusterctl /usr/local/bin/clusterctl
+sudo chown root: /usr/local/bin/clusterctl
+
 # arm (if your Mac has an M1 CPU (”Apple Silicon”))
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.3/clusterctl-darwin-arm64 -o /tmp/clusterctl
 chmod +x /tmp/clusterctl

--- a/prereqs.md
+++ b/prereqs.md
@@ -175,7 +175,6 @@ Install kind v0.16.0 by downloading it from the [kind release page](https://gith
 ```bash
 # amd64
 curl -L https://github.com/kubernetes-sigs/kind/releases/download/v0.16.0/kind-darwin-amd64 -o /tmp/kind
--o /tmp/kind
 chmod +x /tmp/kind
 sudo mv /tmp/kind /usr/local/bin/kind
 sudo chown root: /usr/local/bin/kind


### PR DESCRIPTION
This PR standardizes the install instructions for all arm64/amd64 components in the macos section of the prereqs doc.

There is a little bit of redundancy of info, but IMO this is a bit easier to follow visually when going through the doc.